### PR TITLE
fix(tagger): move from `omerchant` to `merchant` for transaction filtering

### DIFF
--- a/mintamazontagger/tagger.py
+++ b/mintamazontagger/tagger.py
@@ -108,7 +108,7 @@ def get_mint_updates(
     # Skip t if the original description doesn't contain 'amazon'
     merch_whitelist = args.mint_input_merchant_filter.lower().split(',')
     trans = [t for t in trans if any(
-        merch_str in t.omerchant.lower() for merch_str in merch_whitelist)]
+        merch_str in t.merchant.lower() for merch_str in merch_whitelist)]
     stats['amazon_in_desc'] = len(trans)
     # Skip t if it's pending.
     trans = [t for t in trans if not t.is_pending]


### PR DESCRIPTION
Problem:
* Pulling transactions from Amazon, I had ~80.
* 75 were unmatched.

Debugging:
I set up a python debugging environment and I determined that many of my Amazon transactions were being filtered out when mint transactions were being pulled out.

Solution:
I discovered that the reason for this was that `tagger` was filtering transaction on the field `omerchant`, whereas the label "Amazon" was contained on my data at `merchant` or `nmerchant`.

I set the filter to check all fields, `omerchant`, `nmerchant`, and `omerchant` for `whitelist_merch`.

Screenshot:
<img width="523" alt="Screenshot at Dec 25 21-52-02" src="https://user-images.githubusercontent.com/1361104/71457889-cea01800-2765-11ea-9f8d-cf6076b330c8.png">

Now, in my dry run, only 25 are unmatched.

Apologies if my python syntax is not concise, I'm a JS/PHP dev.
