### PR TITLE
Fix access to filelock logger

### DIFF
--- a/mintamazontagger/cli.py
+++ b/mintamazontagger/cli.py
@@ -35,7 +35,9 @@ def main():
     root_logger.setLevel(logging.INFO)
     root_logger.addHandler(logging.StreamHandler())
     # Disable noisy log spam from filelock from within tldextract.
-    filelock.logger().setLevel(logging.WARN)
+    # filelock.logger().setLevel(logging.WARN)
+    logging.getLogger("filelock").setLevel(logging.WARN)
+
     # For helping remote debugging, also log to file.
     # Developers should be vigilant to NOT log any PII, ever (including being
     # mindful of what exceptions might be thrown).


### PR DESCRIPTION
Using recommended call from https://py-filelock.readthedocs.io/en/latest/index.html. I believe this will resolve https://github.com/jprouty/mint-amazon-tagger/issues/83