### PR TITLE
Recognize logins to mint after redesign

### DIFF
--- a/mintamazontagger/mintclient.py
+++ b/mintamazontagger/mintclient.py
@@ -19,7 +19,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 logger = logging.getLogger(__name__)
 
 MINT_HOME = 'https://mint.intuit.com'
-MINT_OVERVIEW = '{}/overview.event'.format(MINT_HOME)
+MINT_OVERVIEW = '{}/overview'.format(MINT_HOME)
 MINT_GET_TRANS = '{}/getJsonData.xevent'.format(MINT_HOME)
 MINT_UPDATE_TRANS = '{}/updateTransaction.xevent'.format(MINT_HOME)
 JSON_HEADER = {'accept': 'application/json'}


### PR DESCRIPTION
I opted to log in manually to mint, and after doing so successfully, `mint-amazon-tagger` did not recognize that I was logged in.

It looks like the test to determine if a user is logged into mint is the URL of the overview page. The URL I guess changed in a recent redesign from `overview.event` to `overview`. Unsure if other changes are required.

Full disclosure, I don't have a dev environment to test this change with so it's completely untested.